### PR TITLE
[CBRD-26165] Add shell test case for SQL statement execution fails after COMMIT is executed inside a loop

### DIFF
--- a/sql/_13_issues/_25_2h/cases/cbrd_26165.sh
+++ b/sql/_13_issues/_25_2h/cases/cbrd_26165.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+. $init_path/init.sh
+init test
+
+dbname=cbrd_26165
+cubrid deletedb $dbname
+
+cubrid_createdb -r $dbname --db-volume-size=20M --log-volume-size=20M
+cubrid server start $dbname
+cubrid broker start
+
+csql -u dba $dbname -i test_commit.sql > output.log 2>&1
+format_csql_output output.log
+compare_result_between_files output.log test_commit.answer
+
+cubrid service stop $dbname
+cubrid deletedb $dbname
+
+rm -rf $dbname
+rm -rf *.log
+
+finish

--- a/sql/_13_issues/_25_2h/cases/test_commit.answer
+++ b/sql/_13_issues/_25_2h/cases/test_commit.answer
@@ -1,0 +1,66 @@
+
+=== <Result of EVALUATE Command in Line 11> ===
+
+  Result              
+======================
+  '1 - COMMIT executed inside a loop'
+
+
+=== <Result of CALL Command in Line 31> ===
+
+  Result              
+======================
+  NULL                
+
+
+=== <Result of SELECT Command in Line 32> ===
+
+           id
+=============
+            1
+            2
+            3
+            4
+            5
+          999
+
+
+=== <Result of EVALUATE Command in Line 34> ===
+
+  Result              
+======================
+  '2 - COMMIT executed via EXECUTE IMMEDIATE inside a loop'
+
+
+=== <Result of CALL Command in Line 55> ===
+
+  Result              
+======================
+  NULL                
+
+
+=== <Result of SELECT Command in Line 56> ===
+
+           id
+=============
+            1
+            2
+            3
+            4
+            5
+          999
+
+
+=== <Result of EVALUATE Command in Line 58> ===
+
+  Result              
+======================
+  '3 - COMMIT executed within a recursive call'
+
+
+=== <Result of SELECT Command in Line 84> ===
+
+       foo(3)
+=============
+            3
+

--- a/sql/_13_issues/_25_2h/cases/test_commit.sql
+++ b/sql/_13_issues/_25_2h/cases/test_commit.sql
@@ -1,0 +1,84 @@
+/**
+ *  This test case verifies CBRD-26165 : SQL statement execution fails after COMMIT is executed inside a loop
+ *  
+ *  Coverage:
+ *  Different Scenario
+1 - COMMIT executed inside a loop
+2 - COMMIT executed via EXECUTE IMMEDIATE inside a loop
+3 - COMMIT executed within a recursive call
+ **/
+
+evaluate '1 - COMMIT executed inside a loop';
+DROP TABLE IF EXISTS test_tbl;
+CREATE TABLE test_tbl(id INT);
+CREATE OR REPLACE PROCEDURE test_pl()
+AS
+    i INT DEFAULT 1;
+BEGIN
+    WHILE i <= 5 LOOP
+        INSERT INTO test_tbl(id) VALUES(i);
+        i := i + 1;
+
+        IF i = 3 THEN
+            COMMIT; 
+        END IF;
+    END LOOP;
+
+    INSERT INTO test_tbl(id) VALUES(999); 
+    COMMIT;
+END;
+
+CALL test_pl();
+SELECT * FROM test_tbl ORDER BY id;
+
+evaluate '2 - COMMIT executed via EXECUTE IMMEDIATE inside a loop';
+DROP TABLE IF EXISTS test_tbl;
+CREATE TABLE test_tbl(id INT);
+
+CREATE OR REPLACE PROCEDURE test_pl()
+AS
+    i INT DEFAULT 1;
+BEGIN
+    WHILE i <= 5 LOOP
+        INSERT INTO test_tbl(id) VALUES(i);
+        i := i + 1;
+
+        IF i = 3 THEN
+            EXECUTE IMMEDIATE 'COMMIT';  
+        END IF;
+    END LOOP;
+   
+    INSERT INTO test_tbl(id) VALUES(999);
+    COMMIT;
+END;
+
+CALL test_pl();
+SELECT * FROM test_tbl ORDER BY id;
+
+evaluate '3 - COMMIT executed within a recursive call';
+DROP TABLE IF EXISTS ttt;
+CREATE TABLE ttt(m INT);
+
+CREATE OR REPLACE FUNCTION foo(n INT) RETURN INT AS
+BEGIN
+    RETURN NULL;
+END;
+
+CREATE OR REPLACE FUNCTION foo(n INT) RETURN INT AS
+    r INT;
+BEGIN
+    IF n <= 0 THEN
+        COMMIT;
+        RETURN 0;
+    END IF;
+
+    FOR i IN 1..n LOOP
+        INSERT INTO ttt VALUES (n);
+        SELECT foo(n-1) INTO r;
+        -- (*)
+    END LOOP;
+
+    RETURN n;
+END;
+
+SELECT foo(3);


### PR DESCRIPTION
Refer to : http://jira.cubrid.org/browse/CBRD-26165

Issue:
SQL statement execution fails after COMMIT is executed inside a loop.

**Test Coverage (under reviewing)** 
Following test scenarios are being cover:
1. COMMIT executed inside a loop
2. COMMIT executed via EXECUTE IMMEDIATE inside a loop
3. COMMIT executed within a recursive call